### PR TITLE
Add Profluent E1 protein language model support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,9 +35,11 @@ jobs:
         pip install -r requirements.txt
         pip install pytest pytest-cov pyright torch
 
-    - name: Run pyright type checker
+    - name: Run pyright type checker on ESM/PLM files
       run: |
-        pyright --pythonversion 3.12
+        # Only check ESM-related files to avoid pre-existing errors in other files
+        # These are the core files for the PLM client implementation
+        pyright app/helpers/esm_client.py app/views/esm_views.py --pythonversion 3.12
 
     - name: Verify critical imports
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,11 +35,9 @@ jobs:
         pip install -r requirements.txt
         pip install pytest pytest-cov pyright torch
 
-    - name: Run pyright type checker on ESM/PLM files
+    - name: Run pyright type checker
       run: |
-        # Only check ESM-related files to avoid pre-existing errors in other files
-        # These are the core files for the PLM client implementation
-        pyright app/helpers/esm_client.py app/views/esm_views.py --pythonversion 3.12
+        pyright --pythonversion 3.12
 
     - name: Verify critical imports
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,11 +33,16 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-cov
+        pip install pytest pytest-cov pyright torch
 
-    - name: Run mypy type checker
+    - name: Run pyright type checker
       run: |
-        mypy app
+        pyright --pythonversion 3.12
+
+    - name: Verify critical imports
+      run: |
+        python -c "from app.helpers.esm_client import FoldyPLMClient, FoldyE1Client, FoldyESMCClient, FoldyESM1and2Client, FoldyESM3Client; print('All client imports OK')"
+        python -c "from app.views.esm_views import ALLOWED_ESM_MODELS, ALLOWED_NATURALNESS_MODELS; print(f'E1 models in allowed list: {[m for m in ALLOWED_ESM_MODELS if m.startswith(\"e1_\")]}')"
 
     - name: Run pytest with coverage
       run: |

--- a/backend/app/helpers/esm_client.py
+++ b/backend/app/helpers/esm_client.py
@@ -56,29 +56,31 @@ def recursive_cleanup(obj):
     return obj  # Return object with cleaned up components
 
 
-class FoldyESMClient(ABC):
+class FoldyPLMClient(ABC):
     """
-    Interface for ESM model clients that provide embedding and logit functionality.
+    Interface for Protein Language Model clients that provide embedding and logit functionality.
 
-    This abstract base class defines the interface that all ESM client
-    implementations must follow.
+    This abstract base class defines the interface that all PLM client
+    implementations must follow. Supports ESM, ESM-C, ESM-3, Profluent E1, and other models.
     """
 
     @classmethod
-    def get_client(cls, model_name: str) -> "FoldyESMClient":
+    def get_client(cls, model_name: str) -> "FoldyPLMClient":
         """
-        Factory method to create appropriate ESM client based on model name.
+        Factory method to create appropriate PLM client based on model name.
 
         Args:
-            model_name: Name of the ESM model to use
+            model_name: Name of the protein language model to use
 
         Returns:
-            An instance of the appropriate FoldyESMClient subclass
+            An instance of the appropriate FoldyPLMClient subclass
 
         Raises:
             ValueError: If model_name does not match any known model type
         """
-        if model_name.startswith("esmc"):
+        if model_name.startswith("e1_"):
+            return FoldyE1Client(model_name)
+        elif model_name.startswith("esmc"):
             return FoldyESMCClient(model_name)
         elif model_name.startswith("esm3"):
             return FoldyESM3Client(model_name)
@@ -129,7 +131,7 @@ class FoldyESMClient(ABC):
         pass
 
 
-class FoldyESMCClient(FoldyESMClient):
+class FoldyESMCClient(FoldyPLMClient):
     """
     ESM-C model client implementation for the foldy platform.
 
@@ -395,7 +397,7 @@ class FoldyESMCClient(FoldyESMClient):
         return pd.DataFrame(melted_rows)
 
 
-class FoldyESM3Client(FoldyESMClient):
+class FoldyESM3Client(FoldyPLMClient):
     """
     ESM-3 model client implementation for the foldy platform.
 
@@ -476,7 +478,7 @@ class FoldyESM3Client(FoldyESMClient):
     get_logits = FoldyESMCClient.get_logits
 
 
-class FoldyESM1and2Client(FoldyESMClient):
+class FoldyESM1and2Client(FoldyPLMClient):
     """
     ESM-1 and ESM-2 model client implementation for the foldy platform.
 
@@ -732,6 +734,238 @@ class FoldyESM1and2Client(FoldyESMClient):
                 if vocab_char in self.alphabet.standard_toks:  # Only include standard amino acids
                     prob = probs[vocab_idx]
                     seq_id = f"{wt_aa}{pos}{vocab_char}"
+                    melted_rows.append({"seq_id": seq_id, "probability": prob})
+
+        return pd.DataFrame(melted_rows)
+
+
+class FoldyE1Client(FoldyPLMClient):
+    """
+    Profluent E1 model client implementation for the foldy platform.
+
+    Handles Profluent E1 specific operations including embedding extraction
+    and logit computation. E1 models are designed as drop-in replacements
+    for ESM models with improved performance.
+    """
+
+    # Standard amino acids for logit output
+    STANDARD_AAS = "ACDEFGHIKLMNPQRSTVWY"
+
+    # Model name mapping from foldy names to HuggingFace names
+    MODEL_NAME_MAP = {
+        "e1_150m": "Profluent-Bio/E1-150m",
+        "e1_300m": "Profluent-Bio/E1-300m",
+        "e1_600m": "Profluent-Bio/E1-600m",
+    }
+
+    def _pool_by_domains(
+        self, hidden_states: "torch.Tensor", domain_boundaries: List[int]
+    ) -> "torch.Tensor":
+        """
+        Pool hidden states by domains and concatenate the results.
+
+        Args:
+            hidden_states: Tensor of shape [seq_len, hidden_dim]
+            domain_boundaries: List of domain boundary positions (0-indexed)
+
+        Returns:
+            Concatenated tensor of domain embeddings
+        """
+        import torch
+
+        if not domain_boundaries:
+            return hidden_states.mean(dim=0)
+
+        # Convert to sorted list and add 0 at the start and seq_len at the end
+        boundaries = [0] + sorted(domain_boundaries) + [hidden_states.shape[0]]
+        domain_embeddings = []
+
+        for i in range(len(boundaries) - 1):
+            start_idx = boundaries[i]
+            end_idx = boundaries[i + 1]
+            domain_embedding = hidden_states[start_idx:end_idx, :].mean(dim=0)
+            domain_embeddings.append(domain_embedding)
+
+        return torch.cat(domain_embeddings, dim=-1)
+
+    def __init__(self, model_name: str) -> None:
+        """
+        Initialize the E1 client with the specified model.
+
+        Args:
+            model_name: Name of the E1 model to load (e1_150m, e1_300m, e1_600m)
+        """
+        import torch
+        from E1.batch_preparer import E1BatchPreparer
+        from E1.modeling import E1ForMaskedLM
+
+        self.model_name = model_name
+        hf_model_name = self.MODEL_NAME_MAP.get(model_name)
+        if not hf_model_name:
+            raise ValueError(
+                f"Unknown E1 model: {model_name}. Available models: {list(self.MODEL_NAME_MAP.keys())}"
+            )
+
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = E1ForMaskedLM.from_pretrained(hf_model_name).to(self.device)
+        self.model.eval()
+
+        # Check for bfloat16 support
+        if self.device.type == "cuda":
+            major, _ = torch.cuda.get_device_capability()
+            self.use_bf16 = major >= 8  # Ampere (RTX 30xx) or newer
+        else:
+            self.use_bf16 = False
+
+        self.batch_preparer = E1BatchPreparer()
+
+        print(
+            f"[E1] Loaded {model_name} ({hf_model_name}) on {self.device} "
+            f"with bf16={'enabled' if self.use_bf16 else 'disabled'}"
+        )
+
+    def embed(
+        self,
+        sequence_or_complex: SequenceOrComplexType,
+        cif_file_path: Optional[str] = None,
+        extra_layers: List[int] = [],
+        domain_boundaries: List[int] = [],
+    ) -> List[List[float]]:
+        """
+        Get embedding for a protein sequence.
+
+        Args:
+            sequence_or_complex: Protein sequence string (complex not supported)
+            cif_file_path: Not supported for E1
+            extra_layers: Not supported for E1
+            domain_boundaries: List of domain boundary positions for domain pooling
+
+        Returns:
+            A list containing the embedding vector(s)
+
+        Raises:
+            ValueError: If a complex, CIF file, or extra_layers are provided (not supported)
+        """
+        import gc
+
+        import torch
+
+        if cif_file_path:
+            raise ValueError("E1 does not support CIF or PDB-based embeddings")
+        if isinstance(sequence_or_complex, list):
+            raise ValueError("E1 does not support protein complexes")
+        if len(extra_layers) > 0:
+            raise ValueError("E1 does not support extra layers")
+
+        sequence = sequence_or_complex
+
+        # Force CUDA synchronization before we start
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        embeddings_result = None
+        try:
+            # Prepare batch using E1BatchPreparer
+            batch = self.batch_preparer.get_batch_kwargs([sequence], device=self.device)
+
+            with torch.no_grad():
+                with torch.autocast("cuda", dtype=torch.bfloat16, enabled=self.use_bf16):
+                    outputs = self.model(
+                        input_ids=batch["input_ids"],
+                        within_seq_position_ids=batch["within_seq_position_ids"],
+                        global_position_ids=batch["global_position_ids"],
+                        sequence_ids=batch["sequence_ids"],
+                        past_key_values=None,
+                        use_cache=False,
+                        output_attentions=False,
+                        output_hidden_states=False,
+                    )
+
+                # Get embeddings for residues only (exclude boundary tokens)
+                residue_selector = ~self.batch_preparer.get_boundary_token_mask(batch["input_ids"])
+                residue_embeddings = outputs.embeddings[0, residue_selector[0]].detach().cpu()
+
+                # Pool by domains
+                pooled_embedding = self._pool_by_domains(residue_embeddings, domain_boundaries)
+                embeddings_result = [pooled_embedding.tolist()]
+
+        finally:
+            # Force garbage collection
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.synchronize()
+
+        return embeddings_result
+
+    def get_logits(
+        self,
+        sequence_or_complex: SequenceOrComplexType,
+        cif_file_path: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """
+        Get logits for a protein sequence.
+
+        Args:
+            sequence_or_complex: Protein sequence string (complex not supported)
+            cif_file_path: Not supported for E1
+
+        Returns:
+            A pandas DataFrame with sequence logits in melted format with
+            columns 'seq_id' and 'probability'
+
+        Raises:
+            ValueError: If a complex or CIF file is provided (not supported)
+        """
+        import torch
+
+        if isinstance(sequence_or_complex, list):
+            raise ValueError("E1 does not support protein complexes")
+        if cif_file_path:
+            raise ValueError("E1 does not support CIF or PDB-based logits")
+
+        sequence = sequence_or_complex
+
+        # Prepare batch
+        batch = self.batch_preparer.get_batch_kwargs([sequence], device=self.device)
+
+        with torch.no_grad():
+            with torch.autocast("cuda", dtype=torch.bfloat16, enabled=self.use_bf16):
+                outputs = self.model(
+                    input_ids=batch["input_ids"],
+                    within_seq_position_ids=batch["within_seq_position_ids"],
+                    global_position_ids=batch["global_position_ids"],
+                    sequence_ids=batch["sequence_ids"],
+                    past_key_values=None,
+                    use_cache=False,
+                    output_attentions=False,
+                    output_hidden_states=False,
+                )
+
+        # Get logits for residues only (exclude boundary tokens)
+        residue_selector = ~self.batch_preparer.get_boundary_token_mask(batch["input_ids"])
+        residue_logits = outputs.logits[0, residue_selector[0]]
+
+        # Convert to probabilities
+        sequence_probs = torch.softmax(residue_logits, dim=-1).cpu()
+
+        # Get the vocabulary from the batch preparer/tokenizer
+        # E1 uses a similar vocabulary structure to ESM
+        vocab = self.batch_preparer.tokenizer.get_vocab()
+        # Create reverse mapping: token_id -> token_str
+        id_to_token = {v: k for k, v in vocab.items()}
+
+        melted_rows: List[Dict[str, Any]] = []
+
+        for pos in range(len(sequence)):  # 0-indexed positions in the filtered output
+            wt_aa = sequence[pos]
+            probs = sequence_probs[pos, :].tolist()
+
+            for aa in self.STANDARD_AAS:
+                if aa in vocab:
+                    token_id = vocab[aa]
+                    prob = probs[token_id]
+                    seq_id = f"{wt_aa}{pos + 1}{aa}"  # 1-based position for seq_id
                     melted_rows.append({"seq_id": seq_id, "probability": prob})
 
         return pd.DataFrame(melted_rows)

--- a/backend/app/helpers/esm_util.py
+++ b/backend/app/helpers/esm_util.py
@@ -36,7 +36,7 @@ def get_naturalness(
     logging.info(f"Creating ESM client for {logit_model}")
     import torch
 
-    from app.helpers.esm_client import FoldyESMClient
+    from app.helpers.esm_client import FoldyPLMClient
 
     # Log cache directories
     torch_cache_dir = torch.hub.get_dir()
@@ -57,7 +57,7 @@ def get_naturalness(
     get_torch_cuda_is_available_and_add_logs(logging.info)
 
     # Create client using factory method
-    client = FoldyESMClient.get_client(logit_model)
+    client = FoldyPLMClient.get_client(logit_model)
     logging.info(f"Model {logit_model} loaded successfully")
 
     # Get logits using the client

--- a/backend/app/jobs/esm_jobs.py
+++ b/backend/app/jobs/esm_jobs.py
@@ -18,7 +18,7 @@ from flask import current_app
 from werkzeug.exceptions import BadRequest
 
 from app.helpers.boltz_yaml_helper import BoltzYamlHelper
-from app.helpers.esm_client import FoldyESMClient
+from app.helpers.esm_client import FoldyPLMClient
 from app.helpers.esm_util import get_naturalness
 from app.helpers.fold_storage_manager import FoldStorageManager
 from app.helpers.gpu_util import clean_up_torch_memory, log_memory_usage
@@ -161,7 +161,7 @@ def get_esm_embeddings(
 
         gpu_available = get_torch_cuda_is_available_and_add_logs(logging.info)
 
-        foldy_esm_client = FoldyESMClient.get_client(embedding_model)
+        foldy_esm_client = FoldyPLMClient.get_client(embedding_model)
 
         def get_embedding_dict(seq_id, seq):
             embedding_list = foldy_esm_client.embed(

--- a/backend/app/tests/test_esm_client.py
+++ b/backend/app/tests/test_esm_client.py
@@ -7,10 +7,11 @@ import pytest
 import torch
 
 from app.helpers.esm_client import (
+    FoldyE1Client,
     FoldyESM1and2Client,
     FoldyESM3Client,
     FoldyESMCClient,
-    FoldyESMClient,
+    FoldyPLMClient,
 )
 
 # Test sequences
@@ -102,11 +103,11 @@ def mock_esm2_hub():
 
 def test_get_client_invalid():
     with pytest.raises(ValueError):
-        FoldyESMClient.get_client("invalid_model")
+        FoldyPLMClient.get_client("invalid_model")
 
 
 def test_esmc_embed(mock_torch_device, mock_esmc_client):
-    client = FoldyESMClient.get_client("esmc_t36_3B_UR50D")
+    client = FoldyPLMClient.get_client("esmc_t36_3B_UR50D")
     embedding = client.embed(TEST_SEQUENCE)
 
     assert isinstance(embedding, list)
@@ -115,13 +116,13 @@ def test_esmc_embed(mock_torch_device, mock_esmc_client):
 
 
 def test_esmc_embed_with_pdb_fails(mock_torch_device, mock_esmc_client):
-    client = FoldyESMClient.get_client("esmc_t36_3B_UR50D")
+    client = FoldyPLMClient.get_client("esmc_t36_3B_UR50D")
     with pytest.raises(ValueError, match="ESM-C does not support PDB-based embeddings"):
         client.embed(TEST_SEQUENCE, TEST_PDB_PATH)
 
 
 def test_esm3_embed_with_pdb_succeeds(mock_torch_device, mock_esm3_client):
-    client = FoldyESMClient.get_client("esm3_t36_3B_UR50D")
+    client = FoldyPLMClient.get_client("esm3_t36_3B_UR50D")
     embedding = client.embed(TEST_SEQUENCE, TEST_PDB_PATH)
 
     assert isinstance(embedding, list)
@@ -130,7 +131,7 @@ def test_esm3_embed_with_pdb_succeeds(mock_torch_device, mock_esm3_client):
 
 
 def test_esm2_embed_with_pdb_fails(mock_torch_device, mock_esm2_hub):
-    client = FoldyESMClient.get_client("esm2_t33_650M_UR50D")
+    client = FoldyPLMClient.get_client("esm2_t33_650M_UR50D")
     with pytest.raises(ValueError, match="do not support PDB-based embeddings"):
         client.embed(TEST_SEQUENCE, TEST_PDB_PATH)
 
@@ -142,7 +143,7 @@ def test_esmc_get_logits(mock_torch_device, mock_esmc_client):
     )  # batch, seq_len + special tokens, vocab_size
     mock_esmc_client.logits.return_value = Mock(logits=Mock(sequence=sequence_logits))
 
-    client = FoldyESMClient.get_client("esmc_t36_3B_UR50D")
+    client = FoldyPLMClient.get_client("esmc_t36_3B_UR50D")
     df = client.get_logits(TEST_SEQUENCE)
 
     assert isinstance(df, pd.DataFrame)
@@ -152,7 +153,7 @@ def test_esmc_get_logits(mock_torch_device, mock_esmc_client):
 
 
 def test_esm2_embed(mock_torch_device, mock_esm2_hub):
-    client = FoldyESMClient.get_client("esm2_t33_650M_UR50D")
+    client = FoldyPLMClient.get_client("esm2_t33_650M_UR50D")
     embedding = client.embed(TEST_SEQUENCE)
 
     assert isinstance(embedding, list)
@@ -161,13 +162,13 @@ def test_esm2_embed(mock_torch_device, mock_esm2_hub):
 
 
 def test_esm2_embed_with_pdb(mock_torch_device, mock_esm2_hub):
-    client = FoldyESMClient.get_client("esm2_t33_650M_UR50D")
+    client = FoldyPLMClient.get_client("esm2_t33_650M_UR50D")
     with pytest.raises(ValueError):
         client.embed(TEST_SEQUENCE, TEST_PDB_PATH)
 
 
 def test_esm2_get_logits(mock_torch_device, mock_esm2_hub):
-    client = FoldyESMClient.get_client("esm2_t33_650M_UR50D")
+    client = FoldyPLMClient.get_client("esm2_t33_650M_UR50D")
     df = client.get_logits(TEST_SEQUENCE)
 
     assert isinstance(df, pd.DataFrame)
@@ -177,13 +178,13 @@ def test_esm2_get_logits(mock_torch_device, mock_esm2_hub):
 
 
 def test_esm2_get_logits_with_pdb(mock_torch_device, mock_esm2_hub):
-    client = FoldyESMClient.get_client("esm2_t33_650M_UR50D")
+    client = FoldyPLMClient.get_client("esm2_t33_650M_UR50D")
     with pytest.raises(ValueError):
         client.get_logits(TEST_SEQUENCE, TEST_PDB_PATH)
 
 
 def test_esm3_embed_with_extra_layers(mock_torch_device, mock_esm3_client):
-    client = FoldyESMClient.get_client("esm3_t36_3B_UR50D")
+    client = FoldyPLMClient.get_client("esm3_t36_3B_UR50D")
     embedding = client.embed(TEST_SEQUENCE, extra_layers=[1, 2, 3])
 
     assert isinstance(embedding, list)

--- a/backend/app/tests/test_esm_client.py
+++ b/backend/app/tests/test_esm_client.py
@@ -18,6 +18,7 @@ from app.helpers.esm_client import (
 TEST_SEQUENCE = "MGSSHHHHHHSSGLVPRGSHM"
 TEST_PDB_PATH = "app/tests/testdata/rubisco-boltz.pdb"
 ESM3_VOCAB_SIZE = 64
+E1_VOCAB_SIZE = 32  # E1 uses a smaller vocabulary
 
 
 @pytest.fixture
@@ -25,6 +26,52 @@ def mock_torch_device():
     with patch("torch.device") as mock_device, patch("torch.cuda.is_available", return_value=False):
         mock_device.return_value = "cpu"
         yield mock_device
+
+
+@pytest.fixture
+def mock_e1_client():
+    """Mock fixture for Profluent E1 model."""
+    with patch("E1.modeling.E1ForMaskedLM") as MockE1Model, \
+         patch("E1.batch_preparer.E1BatchPreparer") as MockBatchPreparer:
+
+        # Create mock model
+        mock_model = Mock()
+        MockE1Model.from_pretrained.return_value = mock_model
+        mock_model.to.return_value = mock_model
+        mock_model.eval.return_value = None
+
+        # Create mock batch preparer
+        mock_batch_preparer = Mock()
+        MockBatchPreparer.return_value = mock_batch_preparer
+
+        # Mock get_batch_kwargs
+        mock_batch = {
+            "input_ids": torch.zeros((1, len(TEST_SEQUENCE) + 2), dtype=torch.long),
+            "within_seq_position_ids": torch.zeros((1, len(TEST_SEQUENCE) + 2), dtype=torch.long),
+            "global_position_ids": torch.zeros((1, len(TEST_SEQUENCE) + 2), dtype=torch.long),
+            "sequence_ids": torch.zeros((1, len(TEST_SEQUENCE) + 2), dtype=torch.long),
+        }
+        mock_batch_preparer.get_batch_kwargs.return_value = mock_batch
+
+        # Mock get_boundary_token_mask - returns True for first and last tokens (boundary)
+        boundary_mask = torch.zeros((1, len(TEST_SEQUENCE) + 2), dtype=torch.bool)
+        boundary_mask[0, 0] = True  # First token is boundary
+        boundary_mask[0, -1] = True  # Last token is boundary
+        mock_batch_preparer.get_boundary_token_mask.return_value = boundary_mask
+
+        # Mock tokenizer vocab
+        mock_tokenizer = Mock()
+        vocab = {aa: i for i, aa in enumerate("ACDEFGHIKLMNPQRSTVWY")}
+        mock_tokenizer.get_vocab.return_value = vocab
+        mock_batch_preparer.tokenizer = mock_tokenizer
+
+        # Mock model forward pass
+        mock_embeddings = torch.randn(1, len(TEST_SEQUENCE) + 2, 1280)
+        mock_logits = torch.randn(1, len(TEST_SEQUENCE) + 2, E1_VOCAB_SIZE)
+        mock_output = Mock(embeddings=mock_embeddings, logits=mock_logits)
+        mock_model.return_value = mock_output
+
+        yield mock_model, mock_batch_preparer
 
 
 @pytest.fixture
@@ -207,3 +254,89 @@ def verify_logits_df_structure(df: pd.DataFrame, sequence: str):
     # Verify seq_id format (e.g., "M1A" for mutation of M at position 1 to A)
     assert all(len(seq_id) >= 3 for seq_id in df["seq_id"])
     assert all(0 <= prob <= 1 for prob in df["probability"])
+
+
+# ============== Profluent E1 Tests ==============
+
+
+def test_get_client_e1_routing(mock_torch_device, mock_e1_client):
+    """Test that E1 model names are routed to FoldyE1Client."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    assert isinstance(client, FoldyE1Client)
+
+
+def test_get_client_e1_all_sizes(mock_torch_device, mock_e1_client):
+    """Test that all E1 model sizes can be instantiated."""
+    for model_name in ["e1_150m", "e1_300m", "e1_600m"]:
+        client = FoldyPLMClient.get_client(model_name)
+        assert isinstance(client, FoldyE1Client)
+
+
+def test_e1_embed(mock_torch_device, mock_e1_client):
+    """Test E1 embedding generation."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    embedding = client.embed(TEST_SEQUENCE)
+
+    assert isinstance(embedding, list)
+    assert len(embedding) == 1
+    assert len(embedding[0]) == 1280  # Expected embedding dimension
+
+
+def test_e1_embed_with_pdb_fails(mock_torch_device, mock_e1_client):
+    """Test that E1 raises error when CIF/PDB file is provided."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    with pytest.raises(ValueError, match="E1 does not support CIF or PDB-based embeddings"):
+        client.embed(TEST_SEQUENCE, TEST_PDB_PATH)
+
+
+def test_e1_embed_with_complex_fails(mock_torch_device, mock_e1_client):
+    """Test that E1 raises error for protein complexes."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    complex_input = [("A", "MGSSH"), ("B", "HHHHH")]
+    with pytest.raises(ValueError, match="E1 does not support protein complexes"):
+        client.embed(complex_input)
+
+
+def test_e1_embed_with_extra_layers_fails(mock_torch_device, mock_e1_client):
+    """Test that E1 raises error when extra_layers is requested."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    with pytest.raises(ValueError, match="E1 does not support extra layers"):
+        client.embed(TEST_SEQUENCE, extra_layers=[1, 2, 3])
+
+
+def test_e1_get_logits(mock_torch_device, mock_e1_client):
+    """Test E1 logits generation."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    df = client.get_logits(TEST_SEQUENCE)
+
+    assert isinstance(df, pd.DataFrame)
+    assert "seq_id" in df.columns
+    assert "probability" in df.columns
+    assert len(df) > 0
+
+
+def test_e1_get_logits_with_pdb_fails(mock_torch_device, mock_e1_client):
+    """Test that E1 raises error for CIF/PDB-based logits."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    with pytest.raises(ValueError, match="E1 does not support CIF or PDB-based logits"):
+        client.get_logits(TEST_SEQUENCE, TEST_PDB_PATH)
+
+
+def test_e1_get_logits_with_complex_fails(mock_torch_device, mock_e1_client):
+    """Test that E1 raises error for complex logits."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    complex_input = [("A", "MGSSH"), ("B", "HHHHH")]
+    with pytest.raises(ValueError, match="E1 does not support protein complexes"):
+        client.get_logits(complex_input)
+
+
+def test_e1_embed_with_domain_boundaries(mock_torch_device, mock_e1_client):
+    """Test E1 embedding with domain pooling."""
+    client = FoldyPLMClient.get_client("e1_300m")
+    # Domain boundary at position 10 (splits sequence into two domains)
+    embedding = client.embed(TEST_SEQUENCE, domain_boundaries=[10])
+
+    assert isinstance(embedding, list)
+    assert len(embedding) == 1
+    # With domain pooling, embedding should be concatenation of 2 domain embeddings
+    assert len(embedding[0]) == 1280 * 2

--- a/backend/app/views/esm_views.py
+++ b/backend/app/views/esm_views.py
@@ -29,15 +29,23 @@ from app.util import get_job_type_replacement
 ns = Namespace("esm_views", decorators=[jwt_required(fresh=True)])
 
 ALLOWED_ESM_MODELS: List[str] = [
+    # Profluent E1 models
+    "e1_150m",
+    "e1_300m",
+    "e1_600m",
+    # ESM-C models
     "esmc_600m",
     "esmc_300m",
+    # ESM-3 models
     "esm3-open",
+    # ESM-2 models
     "esm2_t6_8M_UR50D",
     "esm2_t12_35M_UR50D",
     "esm2_t30_150M_UR50D",
     "esm2_t33_650M_UR50D",
     "esm2_t36_3B_UR50D",
     "esm2_t48_15B_UR50D",
+    # ESM-1v models
     "esm1v_t33_650M_UR90S_1",
     "esm1v_t33_650M_UR90S_2",
     "esm1v_t33_650M_UR90S_3",

--- a/worker/Dockerfile.esm
+++ b/worker/Dockerfile.esm
@@ -33,6 +33,15 @@ RUN /root/.local/bin/uv pip install --python /opt/conda/envs/worker/bin/python -
     accelerate==0.27.2 \
     esm==3.1.3
 
+# Install Profluent E1 model package
+RUN /root/.local/bin/uv pip install --python /opt/conda/envs/worker/bin/python --no-cache \
+    "e1-protein @ git+https://github.com/Profluent-AI/E1.git"
+
+# Install flash-attn for optimal E1 performance on CUDA 8.0+ GPUs (Ampere and newer)
+# This is a hard requirement for E1 models
+RUN /root/.local/bin/uv pip install --python /opt/conda/envs/worker/bin/python --no-cache \
+    flash-attn --no-build-isolation
+
 # TODO(jacob): Move this into setup.sh.
 RUN /opt/conda/bin/conda install -y -n worker -c conda-forge libgcc-ng libstdcxx-ng
 RUN /root/.local/bin/uv pip install --python /opt/conda/envs/worker/bin/python nvidia-ml-py


### PR DESCRIPTION
- Rename FoldyESMClient to FoldyPLMClient for broader model support
- Add FoldyE1Client class implementing embed() and get_logits() methods
- Add e1_150m, e1_300m, e1_600m to allowed models list
- Update Dockerfile.esm to install E1 package and flash-attn
- Update all references across esm_util.py, esm_jobs.py, and tests